### PR TITLE
M5Stack Core2 support: switch to M5Unified and add automatic board-specific pin mapping

### DIFF
--- a/M5Stack-SwitchControlerMonitor.ino
+++ b/M5Stack-SwitchControlerMonitor.ino
@@ -62,7 +62,6 @@ public:
 
         if (len < 7) return;
 
-        // 互換維持のため、フォーク元のSwitch配列解釈をそのまま残す
         padState.btnY = (buf[0] & 0x01);
         padState.btnB = (buf[0] & 0x02);
         padState.btnA = (buf[0] & 0x04);
@@ -95,7 +94,6 @@ const unsigned long SEND_INTERVAL_MS = 200;
 const unsigned long DRAW_INTERVAL_MS = 33;
 const unsigned long DEBUG_POLL_INTERVAL_MS = 200;
 
-// 最低限のデバッグ情報は残す（配線/認識トラブル時の切り分け用）
 uint8_t usbTaskState = USB_STATE_DETACHED;
 int usbIntLevel = -1;
 uint8_t max3421Revision = 0;

--- a/M5Stack-SwitchControlerMonitor.ino
+++ b/M5Stack-SwitchControlerMonitor.ino
@@ -1,9 +1,35 @@
-#include <M5Stack.h>
+#include <M5Unified.h>
 #include <Usb.h>
 #include <usbhub.h>
 #include <hiduniversal.h>
 
-// USB Host Global Objects
+#ifndef USB_MODULE_SS_CH
+#define USB_MODULE_SS_CH 1
+#endif
+
+#ifndef USB_MODULE_INT_CH
+#define USB_MODULE_INT_CH 1
+#endif
+
+#ifndef USB_HOST_SHIELD_SS_GPIO
+#define USB_HOST_SHIELD_SS_GPIO 19
+#endif
+
+#ifndef USB_HOST_SHIELD_INT_GPIO
+#define USB_HOST_SHIELD_INT_GPIO 35
+#endif
+
+#ifndef SERIAL2_RX_PIN
+#if defined(ARDUINO_M5STACK_CORE2) || defined(ARDUINO_M5STACK_Core2)
+#define SERIAL2_RX_PIN 13
+#define SERIAL2_TX_PIN 14
+#else
+#define SERIAL2_RX_PIN 16
+#define SERIAL2_TX_PIN 17
+#endif
+#endif
+
+// USB Host global objects
 USB Usb;
 USBHub Hub(&Usb);
 HIDUniversal Hid(&Usb);
@@ -11,35 +37,32 @@ String lastTxData = "";
 
 // Data structure to hold controller state
 struct ControllerState {
-    uint8_t raw[64]; // Raw report data buffer
+    uint8_t raw[64];
     uint8_t rawLen;
-    
-    // Interpreted values (Standard Switch HID mapping assumption)
-    // Adjust these based on actual raw data observation if needed
+
     bool btnA, btnB, btnX, btnY;
     bool btnL, btnR, btnZL, btnZR;
     bool btnMinus, btnPlus, btnHome, btnCapture;
     bool btnLStick, btnRStick;
-    uint8_t dpad; // Hat switch value (0-7, 8=center)
+    uint8_t dpad;  // Hat switch value (0-7, 8=center)
     uint8_t lX, lY;
     uint8_t rX, rY;
 } padState;
 
-// HID Report Parser Implementation
+// HID report parser implementation
 class ControllerParser : public HIDReportParser {
 public:
-    void Parse(USBHID *hid, bool is_rpt_id, uint8_t len, uint8_t *buf) {
-        // Copy raw data for debugging
+    void Parse(USBHID* hid, bool is_rpt_id, uint8_t len, uint8_t* buf) override {
+        (void)hid;
+        (void)is_rpt_id;
+
         if (len > 64) len = 64;
         memcpy(padState.raw, buf, len);
         padState.rawLen = len;
 
-        // --- Parsing Logic (Tentative for HORI/Switch Wired) ---
-        // Typical Switch Wired format (varies by manufacturer, but often similar)
-        // Byte 0: Button bits (bit0=Y, bit1=B, bit2=A, bit3=X, bit4=L, bit5=R, bit6=ZL, bit7=ZR)
-        // Byte 1: Button bits (bit0=-, bit1=+, bit2=LClick, bit3=RClick, bit4=Home, bit5=Capture)
-        // Byte 2: DPAD (Hat Switch) low nibble? Or Byte 2 is HAT + bits.
+        if (len < 7) return;
 
+        // 互換維持のため、フォーク元のSwitch配列解釈をそのまま残す
         padState.btnY = (buf[0] & 0x01);
         padState.btnB = (buf[0] & 0x02);
         padState.btnA = (buf[0] & 0x04);
@@ -49,15 +72,14 @@ public:
         padState.btnZL = (buf[0] & 0x40);
         padState.btnZR = (buf[0] & 0x80);
 
-        padState.btnMinus   = (buf[1] & 0x01);
-        padState.btnPlus    = (buf[1] & 0x02);
-        padState.btnLStick  = (buf[1] & 0x04);
-        padState.btnRStick  = (buf[1] & 0x08);
-        padState.btnHome    = (buf[1] & 0x10);
+        padState.btnMinus = (buf[1] & 0x01);
+        padState.btnPlus = (buf[1] & 0x02);
+        padState.btnLStick = (buf[1] & 0x04);
+        padState.btnRStick = (buf[1] & 0x08);
+        padState.btnHome = (buf[1] & 0x10);
         padState.btnCapture = (buf[1] & 0x20);
 
-        padState.dpad = buf[2] & 0x0F; // Low nibble usually Hat Switch
-
+        padState.dpad = buf[2] & 0x0F;
         padState.lX = buf[3];
         padState.lY = buf[4];
         padState.rX = buf[5];
@@ -65,191 +87,231 @@ public:
     }
 } parser;
 
-// Wireless Communication Globals
+// Communication and UI update intervals
 unsigned long lastSendTime = 0;
+unsigned long lastDraw = 0;
+unsigned long lastDebugPoll = 0;
 const unsigned long SEND_INTERVAL_MS = 200;
+const unsigned long DRAW_INTERVAL_MS = 33;
+const unsigned long DEBUG_POLL_INTERVAL_MS = 200;
 
-// --- Setup & Loop ---
+// 最低限のデバッグ情報は残す（配線/認識トラブル時の切り分け用）
+uint8_t usbTaskState = USB_STATE_DETACHED;
+int usbIntLevel = -1;
+uint8_t max3421Revision = 0;
+
+void resetPadState() {
+    memset(&padState, 0, sizeof(padState));
+    padState.dpad = 8;
+    padState.lX = 0x80;
+    padState.lY = 0x80;
+    padState.rX = 0x80;
+    padState.rY = 0x80;
+}
+
 void setup() {
-    // Disable USB Serial (3rd arg = false) to suppress debug output
-    // M5.begin(LCDEnable, SDEnable, SerialEnable, I2CEnable);
-    // I2C must be enabled for Power Management (IP5306)
-    M5.begin(true, true, false, true);
+    auto cfg = M5.config();
+    M5.begin(cfg);
 
-    M5.Power.begin();
-    M5.Lcd.setTextSize(2);
-    M5.Lcd.println("M5 Controller Monitor");
-    M5.Lcd.setTextSize(1);
-    M5.Lcd.println("Init USB Host...");
+    resetPadState();
+
+    M5.Display.setRotation(1);
+    M5.Display.setTextSize(2);
+    M5.Display.println("M5 Controller Monitor");
+    M5.Display.setTextSize(1);
+    M5.Display.println("Init USB Host...");
+    M5.Display.printf("DIP: SS CH%d(GPIO%d) / INT CH%d(GPIO%d)\n",
+                      USB_MODULE_SS_CH, USB_HOST_SHIELD_SS_GPIO,
+                      USB_MODULE_INT_CH, USB_HOST_SHIELD_INT_GPIO);
 
     if (Usb.Init() == -1) {
-        M5.Lcd.setTextColor(RED);
-        M5.Lcd.println("OSC did not start.");
-        while (1); // Halt
+        M5.Display.setTextColor(RED);
+        M5.Display.println("OSC did not start.");
+        while (true) {
+            delay(1000);
+        }
     }
-    M5.Lcd.setTextColor(GREEN);
-    M5.Lcd.println("USB Host Init OK");
-    M5.Lcd.setTextColor(WHITE);
+    M5.Display.setTextColor(GREEN);
+    M5.Display.println("USB Host Init OK");
+    M5.Display.setTextColor(WHITE);
 
     if (!Hid.SetReportParser(0, &parser)) {
-        M5.Lcd.println("SetReportParser Error");
+        M5.Display.println("SetReportParser Error");
     }
-    
-    // Initialize Serial2 for Wireless Module
-    // Rx: 16, Tx: 17, 115200bps
-    Serial2.begin(115200, SERIAL_8N1, 16, 17);
-    M5.Lcd.println("Serial2 Started (115200)");
 
-    M5.Lcd.println("Waiting for 5 seconds...");
+    Serial2.begin(115200, SERIAL_8N1, SERIAL2_RX_PIN, SERIAL2_TX_PIN);
+    M5.Display.printf("Serial2 Started (115200) RX:%d TX:%d\n", SERIAL2_RX_PIN,
+                      SERIAL2_TX_PIN);
+    M5.Display.println("Waiting for 5 seconds...");
     delay(5000);
 }
 
 void drawControllerInfo() {
-    // Clear everything below title
-    M5.Lcd.setCursor(0, 15);
-    M5.Lcd.fillRect(0, 15, 320, 220, BLACK); 
+    M5.Display.setCursor(0, 15);
+    M5.Display.fillRect(0, 15, M5.Display.width(), M5.Display.height() - 15, BLACK);
 
-    // Raw Hex Dump (First 8 bytes)
-    M5.Lcd.setCursor(0, 30);
-    M5.Lcd.setTextColor(YELLOW);
-    M5.Lcd.print("RAW: ");
-    for(int i=0; i<8 && i<padState.rawLen; i++) {
-        M5.Lcd.printf("%02X ", padState.raw[i]);
+    M5.Display.setCursor(0, 15);
+    M5.Display.printf("ST:%02X INT:%d REV:%02X\n", usbTaskState, usbIntLevel,
+                      max3421Revision);
+
+    M5.Display.setCursor(0, 30);
+    M5.Display.setTextColor(YELLOW);
+    M5.Display.print("RAW: ");
+    for (int i = 0; i < 8 && i < padState.rawLen; i++) {
+        M5.Display.printf("%02X ", padState.raw[i]);
     }
-    M5.Lcd.println();
-    M5.Lcd.setTextColor(WHITE);
-    
-    // Buttons
-    M5.Lcd.setCursor(0, 50);
-    M5.Lcd.printf("A:%d B:%d X:%d Y:%d\n", padState.btnA, padState.btnB, padState.btnX, padState.btnY);
-    M5.Lcd.printf("L:%d R:%d ZL:%d ZR:%d\n", padState.btnL, padState.btnR, padState.btnZL, padState.btnZR);
-    M5.Lcd.printf("-:%d +:%d H:%d C:%d\n", padState.btnMinus, padState.btnPlus, padState.btnHome, padState.btnCapture);
-    
-    // DPAD Decoding
+    M5.Display.println();
+    M5.Display.setTextColor(WHITE);
+
+    M5.Display.setCursor(0, 50);
+    M5.Display.printf("A:%d B:%d X:%d Y:%d\n", padState.btnA, padState.btnB,
+                      padState.btnX, padState.btnY);
+    M5.Display.printf("L:%d R:%d ZL:%d ZR:%d\n", padState.btnL, padState.btnR,
+                      padState.btnZL, padState.btnZR);
+    M5.Display.printf("-:%d +:%d H:%d C:%d\n", padState.btnMinus,
+                      padState.btnPlus, padState.btnHome, padState.btnCapture);
+
     String dpadStr = "CENTER";
     int dx = 0, dy = 0;
-    switch(padState.dpad) {
-        case 0: dpadStr = "UP";    dy = -1; break;
-        case 1: dpadStr = "UP-R";  dx = 1; dy = -1; break;
-        case 2: dpadStr = "RIGHT"; dx = 1; break;
-        case 3: dpadStr = "DW-R";  dx = 1; dy = 1; break;
-        case 4: dpadStr = "DOWN";  dy = 1; break;
-        case 5: dpadStr = "DW-L";  dx = -1; dy = 1; break;
-        case 6: dpadStr = "LEFT";  dx = -1; break;
-        case 7: dpadStr = "UP-L";  dx = -1; dy = -1; break;
-        default: break;
+    switch (padState.dpad) {
+        case 0:
+            dpadStr = "UP";
+            dy = -1;
+            break;
+        case 1:
+            dpadStr = "UP-R";
+            dx = 1;
+            dy = -1;
+            break;
+        case 2:
+            dpadStr = "RIGHT";
+            dx = 1;
+            break;
+        case 3:
+            dpadStr = "DW-R";
+            dx = 1;
+            dy = 1;
+            break;
+        case 4:
+            dpadStr = "DOWN";
+            dy = 1;
+            break;
+        case 5:
+            dpadStr = "DW-L";
+            dx = -1;
+            dy = 1;
+            break;
+        case 6:
+            dpadStr = "LEFT";
+            dx = -1;
+            break;
+        case 7:
+            dpadStr = "UP-L";
+            dx = -1;
+            dy = -1;
+            break;
+        default:
+            break;
     }
-    M5.Lcd.printf("LS:%d RS:%d DP:%s\n", padState.btnLStick, padState.btnRStick, dpadStr.c_str());
-    
-    // Sticks
-    M5.Lcd.setCursor(0, 100);
-    M5.Lcd.printf("L Stick: X=%3d Y=%3d\n", padState.lX, padState.lY);
-    M5.Lcd.printf("R Stick: X=%3d Y=%3d\n", padState.rX, padState.rY);
+    M5.Display.printf("LS:%d RS:%d DP:%s\n", padState.btnLStick,
+                      padState.btnRStick, dpadStr.c_str());
 
-    // Visual Stick Representation (Simple Box)
-    // Left Stick
+    M5.Display.setCursor(0, 100);
+    M5.Display.printf("L Stick: X=%3d Y=%3d\n", padState.lX, padState.lY);
+    M5.Display.printf("R Stick: X=%3d Y=%3d\n", padState.rX, padState.rY);
+
     int cx = 60, cy = 160, r = 25;
-    M5.Lcd.drawRect(cx-r, cy-r, r*2, r*2, DARKGREY);
+    M5.Display.drawRect(cx - r, cy - r, r * 2, r * 2, DARKGREY);
     int lx = map(padState.lX, 0, 255, -r, r);
     int ly = map(padState.lY, 0, 255, -r, r);
-    M5.Lcd.fillCircle(cx+lx, cy+ly, 4, GREEN);
-    M5.Lcd.setCursor(cx-10, cy+r+5); M5.Lcd.print("LS");
+    M5.Display.fillCircle(cx + lx, cy + ly, 4, GREEN);
+    M5.Display.setCursor(cx - 10, cy + r + 5);
+    M5.Display.print("LS");
 
-    // Right Stick
-    cx = 160; 
-    M5.Lcd.drawRect(cx-r, cy-r, r*2, r*2, DARKGREY);
+    cx = 160;
+    M5.Display.drawRect(cx - r, cy - r, r * 2, r * 2, DARKGREY);
     int rx = map(padState.rX, 0, 255, -r, r);
     int ry = map(padState.rY, 0, 255, -r, r);
-    M5.Lcd.fillCircle(cx+rx, cy+ry, 4, GREEN);
-    M5.Lcd.setCursor(cx-10, cy+r+5); M5.Lcd.print("RS");
+    M5.Display.fillCircle(cx + rx, cy + ry, 4, GREEN);
+    M5.Display.setCursor(cx - 10, cy + r + 5);
+    M5.Display.print("RS");
 
-    // DPAD Visual
     cx = 260;
-    M5.Lcd.drawRect(cx-r, cy-r, r*2, r*2, DARKGREY);
-    // Draw cross guide
-    M5.Lcd.drawLine(cx-r, cy, cx+r, cy, DARKGREY);
-    M5.Lcd.drawLine(cx, cy-r, cx, cy+r, DARKGREY);
-    
-    if (padState.dpad != 8) {
-        M5.Lcd.fillCircle(cx + (dx * 15), cy + (dy * 15), 6, YELLOW);
-    } else {
-        M5.Lcd.fillCircle(cx, cy, 4, DARKGREY);
-    }
-    M5.Lcd.setCursor(cx-15, cy+r+5); M5.Lcd.print("DPAD");
+    M5.Display.drawRect(cx - r, cy - r, r * 2, r * 2, DARKGREY);
+    M5.Display.drawLine(cx - r, cy, cx + r, cy, DARKGREY);
+    M5.Display.drawLine(cx, cy - r, cx, cy + r, DARKGREY);
 
-    // Display sent data
-    M5.Lcd.setCursor(0, 215);
-    M5.Lcd.setTextColor(CYAN);
-    M5.Lcd.print("TX: " + lastTxData);
-    M5.Lcd.setTextColor(WHITE);
+    if (padState.dpad != 8) {
+        M5.Display.fillCircle(cx + (dx * 15), cy + (dy * 15), 6, YELLOW);
+    } else {
+        M5.Display.fillCircle(cx, cy, 4, DARKGREY);
+    }
+    M5.Display.setCursor(cx - 15, cy + r + 5);
+    M5.Display.print("DPAD");
+
+    M5.Display.setCursor(0, 215);
+    M5.Display.setTextColor(CYAN);
+    M5.Display.print("TX: " + lastTxData);
+    M5.Display.setTextColor(WHITE);
 }
 
-unsigned long lastDraw = 0;
+void sendControllerState() {
+    while (Serial2.available()) {
+        Serial2.read();
+    }
+
+    uint8_t byte0 = 0;
+    if (padState.btnA) byte0 |= 0x01;
+    if (padState.btnB) byte0 |= 0x02;
+    if (padState.btnX) byte0 |= 0x04;
+    if (padState.btnY) byte0 |= 0x08;
+    if (padState.btnL) byte0 |= 0x10;
+    if (padState.btnR) byte0 |= 0x20;
+    if (padState.btnZL) byte0 |= 0x40;
+    if (padState.btnZR) byte0 |= 0x80;
+
+    uint8_t byte1 = 0;
+    if (padState.btnMinus) byte1 |= 0x01;
+    if (padState.btnPlus) byte1 |= 0x02;
+    if (padState.btnHome) byte1 |= 0x04;
+    if (padState.btnCapture) byte1 |= 0x08;
+    if (padState.btnLStick) byte1 |= 0x10;
+    if (padState.btnRStick) byte1 |= 0x20;
+
+    uint8_t byte2 = 0;
+    if (padState.dpad == 0x0F || padState.dpad == 8) {
+        byte2 = 0;
+    } else {
+        byte2 = (padState.dpad & 0x0F) + 1;
+    }
+
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%02X,%02X,%02X,%02X,%02X,%02X,%02X\r\n", byte0,
+             byte1, byte2, padState.lX, padState.lY, padState.rX, padState.rY);
+    Serial2.print(buf);
+
+    lastTxData = String(buf);
+    lastTxData.trim();
+}
 
 void loop() {
     Usb.Task();
     M5.update();
-    
-    // Update screen at 30FPS to avoid flicker
-    if (millis() - lastDraw > 33) {
+
+    if (millis() - lastDebugPoll >= DEBUG_POLL_INTERVAL_MS) {
+        lastDebugPoll = millis();
+        usbTaskState = Usb.getUsbTaskState();
+        usbIntLevel = digitalRead(USB_HOST_SHIELD_INT_GPIO);
+        max3421Revision = Usb.regRd(rREVISION);
+    }
+
+    if (millis() - lastDraw > DRAW_INTERVAL_MS) {
         drawControllerInfo();
         lastDraw = millis();
     }
 
-    // Wireless Data Transmission (every 200ms)
     if (millis() - lastSendTime >= SEND_INTERVAL_MS) {
         lastSendTime = millis();
-        
-        // 1. Clear receive buffer (ignore incoming data like "OK")
-        while (Serial2.available()) {
-            Serial2.read();
-        }
-
-        // 2. Prepare Data Packet
-        // Byte 0: A, B, X, Y, L, R, ZL, ZR
-        uint8_t byte0 = 0;
-        if (padState.btnA)  byte0 |= 0x01;
-        if (padState.btnB)  byte0 |= 0x02;
-        if (padState.btnX)  byte0 |= 0x04;
-        if (padState.btnY)  byte0 |= 0x08;
-        if (padState.btnL)  byte0 |= 0x10;
-        if (padState.btnR)  byte0 |= 0x20;
-        if (padState.btnZL) byte0 |= 0x40;
-        if (padState.btnZR) byte0 |= 0x80;
-
-        // Byte 1: -, +, Home, Cap, LClk, RClk
-        uint8_t byte1 = 0;
-        if (padState.btnMinus)   byte1 |= 0x01;
-        if (padState.btnPlus)    byte1 |= 0x02;
-        if (padState.btnHome)    byte1 |= 0x04;
-        if (padState.btnCapture) byte1 |= 0x08;
-        if (padState.btnLStick)  byte1 |= 0x10; // Click
-        if (padState.btnRStick)  byte1 |= 0x20; // Click
-
-        // Byte 2: DPAD (0=Neutral, 1=UP, ... 8=UP-LEFT)
-        // Original: 0=UP, 1=UP-R ... 7=UP-L, 0x0F=Neutral
-        uint8_t byte2 = 0;
-        if (padState.dpad == 0x0F || padState.dpad == 8) {
-             byte2 = 0; // Neutral
-        } else {
-             byte2 = (padState.dpad & 0x0F) + 1;
-        }
-
-        // Byte 3-6: Sticks
-        uint8_t byte3 = padState.lX;
-        uint8_t byte4 = padState.lY;
-        uint8_t byte5 = padState.rX;
-        uint8_t byte6 = padState.rY;
-
-        // 3. Send Formatted String
-        // Format: "XX,XX,XX,XX,XX,XX,XX\r\n"
-        char buf[64];
-        snprintf(buf, sizeof(buf), "%02X,%02X,%02X,%02X,%02X,%02X,%02X\r\n",
-            byte0, byte1, byte2, byte3, byte4, byte5, byte6);
-        Serial2.print(buf);
-        
-        // Update LCD display variable
-        lastTxData = String(buf);
-        lastTxData.trim(); // Remove newline for clean display
+        sendControllerState();
     }
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 M5Stack に USB Host Shield を接続し、Nintendo Switch 用コントローラー (HORI PAD TURBO 等) の入力値をリアルタイムで LCD に表示するモニタリングツールです。
 
+現在は `M5Stack Core2` を優先対象としており、`USB Host Shield Library 2.0` ベースで `M5Stack USB Module v1.2` を利用します。
+UI/電源制御は `M5Unified` 前提で実装しており、`M5Stack.h` ではなく `M5Unified.h` を使用します。
+
 ## 機能
 
 - **USB Host 接続**: M5Stack USB モジュール (MAX3421E) を介してコントローラーを認識
@@ -10,7 +13,9 @@ M5Stack に USB Host Shield を接続し、Nintendo Switch 用コントローラ
     - **アナログスティック**: 左・右スティックの現在値を数値とグラフィックで表示
     - **十字キー (DPAD)**: 押されている方向 (UP, RIGHT, DOWN-LEFT 等) をテキストとビジュアルで表示
 - **デバッグ情報**: 生の HID レポートデータ (Hex Dump) を表示
-- **シリアル通信 (Serial2)**: GPIO 16 (RX), 17 (TX) を使用して、フォーマットされたコントローラー情報を 115200bps で送信 (200ms 間隔)
+- **シリアル通信 (Serial2)**: ボードに応じて UART ピンを自動切替し、フォーマットされたコントローラー情報を 115200bps で送信 (200ms 間隔)
+  - Core: `RX=GPIO16`, `TX=GPIO17`
+  - Core2 (Port C): `RX=GPIO13`, `TX=GPIO14`
 
 ## 送信データフォーマット (Serial2)
 
@@ -56,30 +61,60 @@ M5Stack に USB Host Shield を接続し、Nintendo Switch 用コントローラ
 
 ## 必要ハードウェア
 
-- **M5Stack Core** (Basic, Gray, Fire 等)
+- **M5Stack Core2**
 - **M5Stack USB Module** (MAX3421E 搭載の USB Host Shield)
 - **Nintendo Switch 対応 USB コントローラー** (動作確認済み: HORI PAD TURBO)
+- **HORI PAD TURBO 本体の切替スイッチ**: `Switch 2` 側で使用（`PC` 側だと想定配列になりません）
+
+### USB Module v1.2 の DIP スイッチ設定 (シルク準拠)
+
+実機シルクの `PIN MAP` に合わせ、`SS Select(CH1-CH3)` と `INT Select(CH1-CH2)` を選択します。
+
+| ターゲット | SPI(MOSI/MISO/SCK) | SS CH1 | SS CH2 | SS CH3 | INT CH1 | INT CH2 |
+|:--|:--|:--:|:--:|:--:|:--:|:--:|
+| Core | G23 / G19 / G18 | G13 | G5 | G0 | G35 | G34 |
+| Core2 | G23 / G38 / G18 | G19 | G33 | G0 | G35 | G34 |
+
+このプロジェクトでは、ビルド時に `SS` / `INT` のチャンネルを指定します。
+
+- 既定値: `core2 + SS CH1 + INT CH1` (`GPIO19 / GPIO35`)
+- 例 (`Core2`, `SS CH2`, `INT CH2`):
+```powershell
+.\build.ps1 -Board core2 -SsChannel 2 -IntChannel 2
+```
 
 ## 開発環境 & 依存ライブラリ
 
 ビルドには [Arduino CLI](https://arduino.github.io/arduino-cli/) を使用します。
 
 ### 依存ライブラリ (自動インストールされます)
-- M5Stack
+- M5Unified
 - USB Host Shield Library 2.0
+
+`build.ps1` は `Documents/Arduino/libraries/USB_Host_Shield_Library_2.0` を事前チェックし、無ければインストール、あればそのライブラリに Core/Core2 の `SS/INT/SPI` ピン選択用パッチを自動適用してビルドします。
 
 ## 使い方
 
 プロジェクトのルートディレクトリで `build.ps1` PowerShell スクリプトを実行します。
 
-### ビルドと書き込み (自動検出)
+### ビルドと書き込み (Core2 / 自動検出)
 ```powershell
 .\build.ps1
+```
+
+### ビルドのみ
+```powershell
+.\build.ps1 -SkipUpload
 ```
 
 ### ビルドと書き込み (COMポート指定)
 ```powershell
 .\build.ps1 -Port COM5
+```
+
+### 旧 Core 向けにビルドする場合
+```powershell
+.\build.ps1 -Board core
 ```
 
 ## ライセンス

--- a/build.ps1
+++ b/build.ps1
@@ -1,67 +1,213 @@
 param (
-    [string]$Port = ""
+    [string]$Port = "",
+    [ValidateSet("core", "core2")]
+    [string]$Board = "core2",
+    [ValidateRange(1, 3)]
+    [int]$SsChannel = 1,
+    [ValidateRange(1, 2)]
+    [int]$IntChannel = 1,
+    [switch]$SkipUpload
 )
 
 $ErrorActionPreference = "Stop"
 
-$CoreVersion = "2.1.4"
-# FQBN for M5Stack Core in v2.1.4 seems to be m5stack:esp32:m5stack_core
-$FQBN = "m5stack:esp32:m5stack_core" 
-$SketchName = "M5Stack-SwitchControlerMonitor.ino"
-
-Write-Output "--- M5Stack Build Script (Core v$CoreVersion) ---"
-
-# 1. Install Core
-Write-Output "Checking Core m5stack:esp32@$CoreVersion..."
-# Check if core is installed to avoid slow update-index
-$CoreList = arduino-cli core list | Out-String
-if ($CoreList -match "m5stack:esp32\s+$CoreVersion") {
-    Write-Output "Core $CoreVersion already installed."
+$CoreVersion = "3.2.5"
+$BoardMap = @{
+    core  = "m5stack:esp32:m5stack_core"
+    core2 = "m5stack:esp32:m5stack_core2"
 }
-else {
+
+$SsPinMap = @{
+    core  = @(13, 5, 0)
+    core2 = @(19, 33, 0)
+}
+$IntPinMap = @{
+    core  = @(35, 34)
+    core2 = @(35, 34)
+}
+$MisoPinMap = @{
+    core  = 19
+    core2 = 38
+}
+$UartPinMap = @{
+    core  = @(16, 17) # RX, TX
+    core2 = @(13, 14) # RX, TX (Port C)
+}
+
+$FQBN = $BoardMap[$Board]
+$SketchName = "M5Stack-SwitchControlerMonitor.ino"
+$SelectedSsGpio = $SsPinMap[$Board][$SsChannel - 1]
+$SelectedIntGpio = $IntPinMap[$Board][$IntChannel - 1]
+$SelectedMisoGpio = $MisoPinMap[$Board]
+$SelectedUartRxGpio = $UartPinMap[$Board][0]
+$SelectedUartTxGpio = $UartPinMap[$Board][1]
+
+$UserArduinoDir = Join-Path $HOME "Documents/Arduino"
+$UserLibrariesDir = Join-Path $UserArduinoDir "libraries"
+$UsbHostShieldDir = Join-Path $UserLibrariesDir "USB_Host_Shield_Library_2.0"
+
+Write-Output "--- M5Stack Build Script (Core v$CoreVersion / Board: $Board) ---"
+Write-Output "USB Module DIP: SS CH$SsChannel (GPIO$SelectedSsGpio), INT CH$IntChannel (GPIO$SelectedIntGpio)"
+Write-Output "SPI: SCK=18 MOSI=23 MISO=$SelectedMisoGpio"
+Write-Output "UART(Serial2): RX=$SelectedUartRxGpio TX=$SelectedUartTxGpio"
+Write-Output "Using user library root: $UserLibrariesDir"
+
+function Ensure-CoreInstalled {
+    param([string]$Version)
+    Write-Output "Checking Core m5stack:esp32@$Version..."
+    $CoreList = arduino-cli core list | Out-String
+    if ($CoreList -match "m5stack:esp32\s+$Version") {
+        Write-Output "Core $Version already installed."
+        return
+    }
+
     Write-Output "Installing Core..."
     arduino-cli core update-index
-    arduino-cli core install m5stack:esp32@$CoreVersion
+    arduino-cli core install m5stack:esp32@$Version
 }
 
-# 2. Install Libraries
-Write-Output "Checking Libraries..."
-$LibList = arduino-cli lib list | Out-String
+function Ensure-LibraryInUserFolder {
+    param(
+        [string]$LibraryName,
+        [string]$ExpectedDir
+    )
 
-if ($LibList -match "M5Stack") {
-    Write-Output "Library M5Stack found (skipping install check)."
-}
-else {
-    arduino-cli lib install "M5Stack"
+    if (Test-Path $ExpectedDir) {
+        Write-Output "Library $LibraryName found: $ExpectedDir"
+        return
+    }
+
+    Write-Output "Library $LibraryName not found in Documents/Arduino. Installing..."
+    arduino-cli lib install "$LibraryName"
+
+    if (!(Test-Path $ExpectedDir)) {
+        throw "Library $LibraryName was installed but not found at: $ExpectedDir"
+    }
+
+    Write-Output "Library $LibraryName installed: $ExpectedDir"
 }
 
-if ($LibList -match "USB Host Shield Library 2.0") {
-    Write-Output "Library USB Host Shield Library 2.0 found (skipping install check)."
+function Ensure-UsbHostShieldLibraryPatched {
+    param([string]$LibDir)
+
+    $avrPinsPath = Join-Path $LibDir "avrpins.h"
+    $usbCorePath = Join-Path $LibDir "UsbCore.h"
+
+    if (!(Test-Path $avrPinsPath)) {
+        throw "avrpins.h not found: $avrPinsPath"
+    }
+    if (!(Test-Path $usbCorePath)) {
+        throw "UsbCore.h not found: $usbCorePath"
+    }
+
+    $avrPinsText = Get-Content -Path $avrPinsPath -Raw
+    $requiredPinLines = @(
+        "MAKE_PIN(P13, 13); // Extra SS for M5Stack Core",
+        "MAKE_PIN(P33, 33); // Extra SS for M5Stack Core2",
+        "MAKE_PIN(P34, 34); // Extra INT for M5Stack Core/Core2",
+        "MAKE_PIN(P35, 35); // Extra INT for M5Stack Core/Core2",
+        "MAKE_PIN(P38, 38); // Core2 MISO"
+    )
+
+    $missingPins = @()
+    foreach ($line in $requiredPinLines) {
+        if ($avrPinsText -notmatch [regex]::Escape($line)) {
+            $missingPins += $line
+        }
+    }
+
+    if ($missingPins.Count -gt 0) {
+        $markerPattern = 'MAKE_PIN\(P17,\s*17\);\s*// INT'
+        $regex = [regex]$markerPattern
+        if (!$regex.IsMatch($avrPinsText)) {
+            throw "Could not find insertion marker in avrpins.h: $markerPattern"
+        }
+
+        $insertion = ($missingPins -join "`r`n")
+        $avrPinsText = $regex.Replace($avrPinsText, { param($m) $m.Value + "`r`n" + $insertion }, 1)
+        Set-Content -Path $avrPinsPath -Value $avrPinsText -Encoding UTF8
+        Write-Output "Patched avrpins.h with missing ESP32 pin aliases."
+    }
+
+    $usbCoreText = Get-Content -Path $usbCorePath -Raw
+    if ($usbCoreText -notmatch "USB_HOST_SHIELD_SS_TYPE") {
+        $needle = "typedef MAX3421e<P5, P17> MAX3421E; // ESP32 boards"
+        $replacement = @"
+#ifndef USB_HOST_SHIELD_SS_TYPE
+#define USB_HOST_SHIELD_SS_TYPE P5
+#endif
+#ifndef USB_HOST_SHIELD_INT_TYPE
+#define USB_HOST_SHIELD_INT_TYPE P17
+#endif
+typedef MAX3421e<USB_HOST_SHIELD_SS_TYPE, USB_HOST_SHIELD_INT_TYPE> MAX3421E; // ESP32 boards (customizable)
+"@
+
+        if ($usbCoreText.Contains($needle)) {
+            $usbCoreText = $usbCoreText.Replace($needle, $replacement.Trim())
+            Set-Content -Path $usbCorePath -Value $usbCoreText -Encoding UTF8
+            Write-Output "Patched UsbCore.h for customizable ESP32 SS/INT pins."
+        }
+        else {
+            throw "Expected ESP32 typedef was not found in UsbCore.h"
+        }
+    }
 }
-else {
-    arduino-cli lib install "USB Host Shield Library 2.0"
+
+# 1. Core
+Ensure-CoreInstalled -Version $CoreVersion
+
+# 2. Libraries (Documents/Arduino 配下を必須にする)
+if (!(Test-Path $UserLibrariesDir)) {
+    New-Item -ItemType Directory -Path $UserLibrariesDir | Out-Null
 }
+
+Ensure-LibraryInUserFolder -LibraryName "M5Unified" -ExpectedDir (Join-Path $UserLibrariesDir "M5Unified")
+Ensure-LibraryInUserFolder -LibraryName "USB Host Shield Library 2.0" -ExpectedDir $UsbHostShieldDir
+Ensure-UsbHostShieldLibraryPatched -LibDir $UsbHostShieldDir
 
 # 3. Compile
 Write-Output "Compiling $SketchName..."
 Write-Output "FQBN: $FQBN"
-arduino-cli compile --fqbn $FQBN .
 
-if ($LASTEXITCODE -eq 0) {
-    Write-Output "Build successful!"
-}
-else {
+$SsType = "P$SelectedSsGpio"
+$IntType = "P$SelectedIntGpio"
+
+$ExtraFlags = @(
+    "-DESP32",
+    "-DUSB_HOST_SHIELD_SS_TYPE=$SsType",
+    "-DUSB_HOST_SHIELD_INT_TYPE=$IntType",
+    "-DPIN_SPI_SCK=18",
+    "-DPIN_SPI_MOSI=23",
+    "-DPIN_SPI_MISO=$SelectedMisoGpio",
+    "-DPIN_SPI_SS=$SelectedSsGpio",
+    "-DUSB_MODULE_SS_CH=$SsChannel",
+    "-DUSB_MODULE_INT_CH=$IntChannel",
+    "-DUSB_HOST_SHIELD_SS_GPIO=$SelectedSsGpio",
+    "-DUSB_HOST_SHIELD_INT_GPIO=$SelectedIntGpio",
+    "-DSERIAL2_RX_PIN=$SelectedUartRxGpio",
+    "-DSERIAL2_TX_PIN=$SelectedUartTxGpio"
+) -join " "
+
+Write-Output "Build flags: $ExtraFlags"
+arduino-cli compile --fqbn $FQBN --libraries $UserLibrariesDir --build-property "build.extra_flags=$ExtraFlags" .
+
+if ($LASTEXITCODE -ne 0) {
     Write-Output "Build failed!"
     exit 1
 }
+Write-Output "Build successful!"
 
 # 4. Upload
+if ($SkipUpload) {
+    Write-Output "SkipUpload specified. Build only."
+    exit 0
+}
+
 if ($Port -eq "") {
     Write-Output "Detecting COM port..."
     $BoardListOutput = arduino-cli board list | Out-String
     Write-Output $BoardListOutput
 
-    # Simple parsing to find a likely port (first COM port found)
     $Lines = $BoardListOutput -split "`r`n"
     foreach ($Line in $Lines) {
         if ($Line -match "(COM\d+)") {
@@ -78,7 +224,7 @@ if ($Port) {
     Write-Output "Found port: $Port"
     Write-Output "Uploading to $Port..."
     arduino-cli upload -p $Port --fqbn $FQBN .
-    
+
     if ($LASTEXITCODE -eq 0) {
         Write-Output "Upload successful!"
     }


### PR DESCRIPTION
## 概要
M5Stack Core2 で `M5Stack USB Module v1.2` + HORIコントローラを使えるようにするための対応です。  
あわせて、ボード差分によるピン設定ミスを避けるため、USBモジュールとSerial2のピンをボード別に自動割当するようにしました。

## 主な変更
- `M5Stack.h` から `M5Unified.h` へ移行
- ボード別ピン割当の導入
  - USB Module (SS/INT): `build.ps1` の `-Board/-SsChannel/-IntChannel` で自動反映
  - Serial2:
    - Core: `RX=GPIO16 / TX=GPIO17`
    - Core2 (Port C): `RX=GPIO13 / TX=GPIO14`
- `build.ps1` を拡張
  - `core / core2` 切替対応
  - `Documents/Arduino/libraries` 配下のライブラリ存在チェック
  - `USB Host Shield Library 2.0` への必要パッチ自動適用
- README 更新
  - Core2前提の手順、DIP設定、依存ライブラリ、UARTピン説明を明確化
  - `M5Unified` 前提であることを明記

## 動作確認
- ビルド: `.\build.ps1 -Board core2 -SsChannel 1 -IntChannel 1`
- USB Host 初期化 / HID認識 / レポート受信を確認
- UART送信が無線モジュール側で受信されることを確認

## 互換性・補足
- Core向け設定も `-Board core` で維持
- 既存の起動時待機（5秒）は upstream の挙動に合わせて維持
- HORI PAD TURBO は本体スイッチを `Switch 2` 側で使用
